### PR TITLE
nersc_hours: add "--noconvert" flag to display raw node counts for easier parsing

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -94,7 +94,7 @@ nersc_hours ()
     if [[ $jobid == "null" ]]; then
       local usage="$walltime|$nodes|"
     else
-      local usage=$(sacct -a -n -X -p -o Elapsed,$unit -j $jobid)
+      local usage=$(sacct -a -n -X -p -o Elapsed,$unit -j $jobid --noconvert)
     fi
     usage=${usage%|}
     local dhms=${usage%%|*}


### PR DESCRIPTION
For large jobs, Slurm may abbreviate the number of nodes used by applying the
"K" unit. This makes it more human-readable but less machine-readable and
parsable, so add the "--noconvert" flag to always display the raw node counts
so that nersc_hours()'s job is easier.